### PR TITLE
Fixed H2 on License

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ can be. If you want an example of how powerfull this technique can be you can ch
 
 ---
 
-##License
+## License
  
-    The MIT License
+    The MIT C
     
     Copyright (c) 2016 Alberto Sanz
     

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ can be. If you want an example of how powerfull this technique can be you can ch
 
 ## License
  
-    The MIT C
+    The MIT License
     
     Copyright (c) 2016 Alberto Sanz
     


### PR DESCRIPTION
There was a missing space between `##` and `License`.